### PR TITLE
Bump `pillow_heif` to `0.18.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pillow>=9.2.0
-pillow_heif==0.14.0
+pillow_heif>=0.18.0
 piexif==1.1.3


### PR DESCRIPTION
Script failed for me with `cannot identify image file` (no error at all in UI).
Underlying error was `UnidentifiedImageError`, as in https://github.com/bigcat88/pillow_heif/issues/249
This was fixed with https://github.com/bigcat88/pillow_heif/releases/tag/v0.18.0, so bumping to that version seemed appropriate.

I can't speak to backwards compatibility, but since its a minor version change I would expect nothing to break. With my example images everything still works (including exif).

[Release notes](https://github.com/bigcat88/pillow_heif/releases/tag/v0.16.0) of `0.16.0` list breaking changes for monochrome images though.